### PR TITLE
typo : write the remaining days in singular when it's equal to one

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -74,7 +74,7 @@ export default function Home() {
           >
             <Image src={url} width={32} height={32} />
             <div className={classNames("ml-2", colorClassName)}>
-              {days} days left
+              {days == 1 ? "1 day left" : `${days} days left`}
             </div>
           </div>
         </>


### PR DESCRIPTION
The remaining days are always written in plural even when one day is left,
-> Write the remaining days in singular when it's equal to one